### PR TITLE
set dpi param 96>91 regarding ogc in example

### DIFF
--- a/example/example.map
+++ b/example/example.map
@@ -5,8 +5,8 @@ MAP
   UNITS         meters
   STATUS        ON
 
-  RESOLUTION 96
-  DEFRESOLUTION 96
+  RESOLUTION 91
+  DEFRESOLUTION 91
 
   PROJECTION
     "init=epsg:4326"


### PR DESCRIPTION
"OpenGIS® Web Map Server Implementation Specification" - Version: 1.3.0 - OGC® 06-042 - 2006-03-15
Page 27: 7.2.4.6.9 Scale denominators