### PR TITLE
added wms getfeatureinfo list

### DIFF
--- a/example/example.map
+++ b/example/example.map
@@ -43,6 +43,7 @@ MAP
     END
   END
 
+ # outputformat used by WMS GetFeatureInfo and the WFS GetFeature requests
   OUTPUTFORMAT
     NAME "GEOJSON"       # format name (visible as format in the 1.0.0 capabilities)
     DRIVER "OGR/GEOJSON"
@@ -54,6 +55,7 @@ MAP
     FORMATOPTION "LCO:ID_TYPE=STRING"
   END
 
+  # outputformat used by WMS GetFeatureInfo and the WFS GetFeature requests
   OUTPUTFORMAT
     NAME "JSON"
     DRIVER "OGR/GEOJSON"
@@ -65,6 +67,7 @@ MAP
     FORMATOPTION "LCO:ID_TYPE=STRING"
   END
 
+  # outputformat used by WMS GetFeatureInfo request, not the WFS GetFeature requests
   OUTPUTFORMAT
     NAME "XML"
     DRIVER "OGR/GML"
@@ -77,6 +80,7 @@ MAP
     FORMATOPTION "DSCO:XSISCHEMAURI=http://example.unknown.org"
   END
 
+  # outputformat used by WMS GetFeatureInfo request, not the WFS GetFeature requests
   OUTPUTFORMAT
     NAME "OGRGML3"
     DRIVER "OGR/GML"
@@ -92,6 +96,7 @@ MAP
     FORMATOPTION "DSCO:XSISCHEMAURI=http://example.unknown.org http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd"
   END
 
+  # outputformat used by WMS GetFeatureInfo requests, not the WFS GetFeature requests
   OUTPUTFORMAT
     NAME "OGRGML32"
     DRIVER "OGR/GML"
@@ -100,7 +105,7 @@ MAP
     FORMATOPTION "FORM=SIMPLE"
     FORMATOPTION "USE_FEATUREID=true"
     FORMATOPTION "DSCO:FORMAT=GML3.2"
-    FORMATOPTION "DSCO:GML_ID=example.collection"
+    FORMATOPTION "DSCO:GML_ID=wms.example.getfeatureinfo.collection"
     FORMATOPTION "DSCO:GML_FEATURE_COLLECTION=YES"
     FORMATOPTION "DSCO:PREFIX=example"
     FORMATOPTION "DSCO:XSISCHEMA=EXTERNAL"
@@ -108,6 +113,7 @@ MAP
     FORMATOPTION "DSCO:XSISCHEMAURI=http://example.unknown.org http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
   END  
    
+  # outputformat used by WMS GetMap requests
   OUTPUTFORMAT
     NAME "SVG"
     DRIVER CAIRO/SVG
@@ -116,6 +122,7 @@ MAP
     EXTENSION "svg"
   END
 
+  # outputformat used by tiled requests
   OUTPUTFORMAT
     NAME "mvt"
     DRIVER MVT
@@ -143,7 +150,7 @@ MAP
       "wms_namespace_prefix"           "example"
       "wms_namespace_uri"              "http://example.unknown.org"
       "wms_getfeatureinfo_formatlist"  "text/html,text/xml; subtype=gml/3.2.1,text/xml; subtype=gml/3.1.1,application/json,application/json; subtype=geojson"
-      
+
       "ows_sld_enabled"                "false"
     END
   END

--- a/example/example.map
+++ b/example/example.map
@@ -35,6 +35,7 @@ MAP
       "ows_role"                         ""
       "ows_srs"                          "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"
       "ows_accessconstraints"            "otherRestrictions;http://creativecommons.org/publicdomain/mark/1.0"      
+      "wms_getfeatureinfo_formatlist"    "application/vnd.ogc.gml,text/html,text/plain,application/json,application/json; subtype=geojson,text/xml,text/xml; subtype=gml/3.1.1"
     END
   END
 
@@ -81,6 +82,9 @@ MAP
     FORMATOPTION "STORAGE=stream"
     FORMATOPTION "FORM=SIMPLE"
     FORMATOPTION "USE_FEATUREID=true"
+    FORMATOPTION "DSCO:GML_ID=fid"
+    FORMATOPTION "DSCO:PREFIX=example"
+    FORMATOPTION "DSCO:XSISCHEMAURI=http://example.unknown.org"
   END
 
    

--- a/example/example.map
+++ b/example/example.map
@@ -10,7 +10,7 @@ MAP
 
   PROJECTION
     "init=epsg:4326"
-  END      
+  END
 
   WEB
     METADATA
@@ -39,8 +39,7 @@ MAP
     END
   END
 
-
-   OUTPUTFORMAT
+  OUTPUTFORMAT
     NAME "GEOJSON"       # format name (visible as format in the 1.0.0 capabilities)
     DRIVER "OGR/GEOJSON"
     MIMETYPE "application/json; subtype=geojson"
@@ -62,7 +61,6 @@ MAP
     FORMATOPTION "LCO:ID_TYPE=STRING"
   END
 
-  
   OUTPUTFORMAT
     NAME "XML"
     DRIVER "OGR/GML"
@@ -82,11 +80,29 @@ MAP
     FORMATOPTION "STORAGE=stream"
     FORMATOPTION "FORM=SIMPLE"
     FORMATOPTION "USE_FEATUREID=true"
-    FORMATOPTION "DSCO:GML_ID=fid"
+    FORMATOPTION "DSCO:FORMAT=GML3Deegree"
+    FORMATOPTION "DSCO:GML_FEATURE_COLLECTION=YES"
     FORMATOPTION "DSCO:PREFIX=example"
-    FORMATOPTION "DSCO:XSISCHEMAURI=http://example.unknown.org"
+    FORMATOPTION "DSCO:XSISCHEMA=EXTERNAL"
+    FORMATOPTION "DSCO:TARGET_NAMESPACE=http://example.unknown.org"
+    FORMATOPTION "DSCO:XSISCHEMAURI=http://example.unknown.org http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd"
   END
 
+  OUTPUTFORMAT
+    NAME "GML32"
+    DRIVER "OGR/GML"
+    MIMETYPE "text/xml; subtype=gml/3.2.1"
+    FORMATOPTION "STORAGE=stream"
+    FORMATOPTION "FORM=SIMPLE"
+    FORMATOPTION "USE_FEATUREID=true"
+    FORMATOPTION "DSCO:FORMAT=GML3.2"
+    FORMATOPTION "DSCO:GML_ID=example.collection"
+    FORMATOPTION "DSCO:GML_FEATURE_COLLECTION=YES"
+    FORMATOPTION "DSCO:PREFIX=example"
+    FORMATOPTION "DSCO:XSISCHEMA=EXTERNAL"
+    FORMATOPTION "DSCO:TARGET_NAMESPACE=http://example.unknown.org"
+    FORMATOPTION "DSCO:XSISCHEMAURI=http://example.unknown.org http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd"
+  END  
    
   OUTPUTFORMAT
     NAME "SVG"
@@ -98,7 +114,7 @@ MAP
 
   OUTPUTFORMAT
     NAME "mvt"
-    DRIVER MVT  
+    DRIVER MVT
     FORMATOPTION "EDGE_BUFFER=20"
     EXTENSION "pbf"
     FORMATOPTION "EXTENT=4096"
@@ -114,15 +130,15 @@ MAP
       "wfs_extent"                     "2 50 9 54"
       "wfs_namespace_prefix"           "example"
       "wfs_namespace_uri"              "http://example.unknown.org"
-      "wfs_getfeature_formatlist"      "GEOJSON,JSON,XML,GML3"
+      "wfs_getfeature_formatlist"      "GEOJSON,JSON,XML,GML3,GML32"
       "wfs_maxfeatures"                "1000"
 
       "wms_getmap_formatlist"          "image/png,image/jpeg,image/png; mode=8bit,image/vnd.jpeg-png,image/vnd.jpeg-png8,image/svg+xml"
-      "wms_enable_request"             "* !GetStyles"         
-      "wms_bbox_extended"              "true" 
+      "wms_enable_request"             "* !GetStyles !DescribeLayer"
+      "wms_bbox_extended"              "true"
       "wms_namespace_prefix"           "example"
       "wms_namespace_uri"              "http://example.unknown.org"
-      "wms_feature_info_mime_type"     "application/json,application/json; subtype=geojson,application/vnd.ogc.gml,text/html,text/plain,text/xml,text/xml; subtype=gml/3.1.1"
+      "wms_getfeatureinfo_formatlist"  "text/html,text/xml; subtype=gml/3.2.1,text/xml; subtype=gml/3.1.1,application/json,application/json; subtype=geojson"
     END
   END
 
@@ -132,29 +148,26 @@ MAP
     TYPE POLYGON
 
     METADATA
-      "ows_featureid"           "id"
-      
       "wfs_title"               "example"
       "wfs_abstract"            "Layer containing the example data"
       "wfs_srs"                 "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"      
-      "wfs_extent"              "2 50 9 54"      
+      "wfs_extent"              "2 50 9 54"
       "wfs_bbox_extended"       "true"
       "wfs_enable_request"      "*"
       "wfs_include_items"       "all"
 
-      "gml_include_items" "all"
-      "gml_exclude_items" "id"
-      "gml_msfid_alias"   "fid"
-      "gml_featureid"     "id"
-      "gml_geometries"    "geom"
-      "gml_types"         "auto"
+      "gml_include_items"       "all"
+      "gml_exclude_items"       "id"
+      "gml_featureid"           "id"
+      "gml_geometries"          "geom"
+      "gml_types"               "auto"
 
       "wms_title"               "example"
       "wms_extent"              "2 50 9 54"    
       "wms_abstract"            "Layer containing the example data"
       "wms_srs"                 "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"
       "wms_keywordlist"         "example,unknown"
-      "wms_include_items"       "all" 
+      "wms_include_items"       "all"
     END
 
     CLASSGROUP "example:style"

--- a/example/example.map
+++ b/example/example.map
@@ -4,6 +4,11 @@ MAP
   EXTENT        2 50 9 54
   UNITS         meters
   STATUS        ON
+  SIZE          5000 5000
+  
+  ## global debug settings for mapserver, remove comment in lines below to enable
+  # DEBUG         4         # https://mapserver.org/optimization/debugging.html
+  # CONFIG "CPL_DEBUG" "ON" # GDAL
 
   RESOLUTION 91
   DEFRESOLUTION 91
@@ -35,7 +40,6 @@ MAP
       "ows_role"                         ""
       "ows_srs"                          "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"
       "ows_accessconstraints"            "otherRestrictions;http://creativecommons.org/publicdomain/mark/1.0"      
-      "wms_getfeatureinfo_formatlist"    "application/vnd.ogc.gml,text/html,text/plain,application/json,application/json; subtype=geojson,text/xml,text/xml; subtype=gml/3.1.1"
     END
   END
 
@@ -74,7 +78,7 @@ MAP
   END
 
   OUTPUTFORMAT
-    NAME "GML3"
+    NAME "OGRGML3"
     DRIVER "OGR/GML"
     MIMETYPE "text/xml; subtype=gml/3.1.1"
     FORMATOPTION "STORAGE=stream"
@@ -89,7 +93,7 @@ MAP
   END
 
   OUTPUTFORMAT
-    NAME "GML32"
+    NAME "OGRGML32"
     DRIVER "OGR/GML"
     MIMETYPE "text/xml; subtype=gml/3.2.1"
     FORMATOPTION "STORAGE=stream"
@@ -129,9 +133,9 @@ MAP
 
       "wfs_extent"                     "2 50 9 54"
       "wfs_namespace_prefix"           "example"
-      "wfs_namespace_uri"              "http://example.unknown.org"
-      "wfs_getfeature_formatlist"      "GEOJSON,JSON,XML,GML3,GML32"
+      "wfs_namespace_uri"              "http://example.unknown.org"      
       "wfs_maxfeatures"                "1000"
+      "wfs_onlineresource"             "http://localhost"
 
       "wms_getmap_formatlist"          "image/png,image/jpeg,image/png; mode=8bit,image/vnd.jpeg-png,image/vnd.jpeg-png8,image/svg+xml"
       "wms_enable_request"             "* !GetStyles !DescribeLayer"
@@ -139,6 +143,8 @@ MAP
       "wms_namespace_prefix"           "example"
       "wms_namespace_uri"              "http://example.unknown.org"
       "wms_getfeatureinfo_formatlist"  "text/html,text/xml; subtype=gml/3.2.1,text/xml; subtype=gml/3.1.1,application/json,application/json; subtype=geojson"
+      
+      "ows_sld_enabled"                "false"
     END
   END
 
@@ -146,28 +152,31 @@ MAP
     NAME "example"
     STATUS ON
     TYPE POLYGON
+    ## layer debug settings for mapserver, remove comment in lines below to enable
+    # DEBUG 4
 
     METADATA
-      "wfs_title"               "example"
-      "wfs_abstract"            "Layer containing the example data"
-      "wfs_srs"                 "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"      
-      "wfs_extent"              "2 50 9 54"
-      "wfs_bbox_extended"       "true"
-      "wfs_enable_request"      "*"
-      "wfs_include_items"       "all"
+      "wfs_title"                    "example"
+      "wfs_abstract"                 "Layer containing the example data"
+      "wfs_srs"                      "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"      
+      "wfs_extent"                   "2 50 9 54"
+      "wfs_bbox_extended"            "true"
+      "wfs_enable_request"           "*"
+      "wfs_include_items"            "all"
+      "wfs_getfeature_formatlist"    "OGRGML3,OGRGML32,GEOJSON,JSON"
 
-      "gml_include_items"       "all"
-      "gml_exclude_items"       "id"
-      "gml_featureid"           "id"
-      "gml_geometries"          "geom"
-      "gml_types"               "auto"
+      "gml_include_items"            "all"
+      "gml_exclude_items"            "id"
+      "gml_featureid"                "id"
+      "gml_geometries"               "geom"
+      "gml_types"                    "auto"
 
-      "wms_title"               "example"
-      "wms_extent"              "2 50 9 54"    
-      "wms_abstract"            "Layer containing the example data"
-      "wms_srs"                 "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"
-      "wms_keywordlist"         "example,unknown"
-      "wms_include_items"       "all"
+      "wms_title"                    "example"
+      "wms_extent"                   "2 50 9 54"    
+      "wms_abstract"                 "Layer containing the example data"
+      "wms_srs"                      "EPSG:4326 EPSG:3857 EPSG:4258 EPSG:900913 CRS:84"
+      "wms_keywordlist"              "example,unknown"
+      "wms_include_items"            "all"
     END
 
     CLASSGROUP "example:style"


### PR DESCRIPTION
lijst van getfeatureinfo formats toegevoegd aan mapfile.

---
De wms getfeaturinfo `text/xml; subtype=gml/3.1.1` is nog niet hetzelfde als de wfs getfeature met dit format, dit probleem moet nog opgelost worden.

# WMS GetFeatureInfo request GML 3.1 

http://localhost/?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetFeatureInfo&BBOX=49.76696185286103713,1.82499999999999929,54.23303814713896287,9.17500000000000071&CRS=EPSG:4326&WIDTH=1468&HEIGHT=892&LAYERS=example&STYLES=&FORMAT=image/png&QUERY_LAYERS=example&INFO_FORMAT=text/xml;%20subtype=gml/3.1.1&I=913&J=560

```
<?xml version="1.0" encoding="utf-8" ?>
<example:FeatureCollection
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://example.unknown.org"
     xmlns:example="http://ogr.maptools.org/"
     xmlns:gml="http://www.opengis.net/gml">
  <gml:boundedBy><gml:null>missing</gml:null></gml:boundedBy>
  <gml:featureMember>
    <example:example fid="example.f54f184e-175a-466a-8819-4765b83e8113">
      <example:geometryProperty><gml:Polygon srsName="EPSG:4326"><gml:outerBoundaryIs><gml:LinearRing><gml:coordinates>6.03016409694165,51.1376941300921 6.03652461227397,51.5871062219341 6.75784981102538,51.5808735310983 6.74442861322796,51.1315411915845 6.03016409694165,51.1376941300921</gml:coordinates></gml:LinearRing></gml:outerBoundaryIs></gml:Polygon></example:geometryProperty>
      <example:name>twenty-two</example:name>
    </example:example>
  </gml:featureMember>
</example:FeatureCollection>
```

# WFS GetFeature request GML 3.1

http://localhost/?request=getfeature&service=wfs&version=2.0.0&typename=example:example&resourceid=example.988fd9a0-665d-40ec-8c82-c188b023da3a&outputFormat=text/xml;%20subtype=gml/3.1.1

```
<?xml version='1.0' encoding="UTF-8" ?>
<wfs:FeatureCollection
   xmlns:example="http://example.unknown.org"
   xmlns:gml="http://www.opengis.net/gml"
   xmlns:wfs="http://www.opengis.net/wfs/2.0"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://example.unknown.org http://localhost/?SERVICE=WFS&amp;VERSION=2.0.0&amp;REQUEST=DescribeFeatureType&amp;TYPENAME=example:example&amp;OUTPUTFORMAT=SFE_XMLSCHEMA http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd http://www.opengis.net/gml http://schemas.opengis.net/gml/3.1.1/base/gml.xsd"
   timeStamp="2020-06-02T08:00:07" numberMatched="1" numberReturned="1">
      <wfs:boundedBy>
      	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
      		<gml:lowerCorner>51.118368 3.151387</gml:lowerCorner>
      		<gml:upperCorner>51.579097 3.887149</gml:upperCorner>
      	</gml:Envelope>
      </wfs:boundedBy>
    <wfs:member>
      <example:example gml:id="example.988fd9a0-665d-40ec-8c82-c188b023da3a">
        <gml:boundedBy>
        	<gml:Envelope srsName="urn:ogc:def:crs:EPSG::4326">
        		<gml:lowerCorner>51.118368 3.151387</gml:lowerCorner>
        		<gml:upperCorner>51.579097 3.887149</gml:upperCorner>
        	</gml:Envelope>
        </gml:boundedBy>
        <example:geom>
          <gml:Polygon srsName="urn:ogc:def:crs:EPSG::4326">
            <gml:exterior>
              <gml:LinearRing>
                <gml:posList srsDimension="2">51.118368 3.173263 51.567530 3.151387 51.579097 3.872320 51.129788 3.887149 51.118368 3.173263 </gml:posList>
              </gml:LinearRing>
            </gml:exterior>
          </gml:Polygon>
        </example:geom>
        <example:fid>example.988fd9a0-665d-40ec-8c82-c188b023da3a</example:fid>
        <example:name>two</example:name>
      </example:example>
    </wfs:member>
</wfs:FeatureCollection>
```
