### PR TITLE
PDOK-13906 lighttpd config include for flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,40 @@ The included EPSG file containing the projection parameters only contains a
 small set of available EPSG code, namely the once used by our organization. If
 one wants to use additional EPSG projections one can overwrite this file.
 
+### Passing extra environment variables to MapServer
+
+If you need to pass extra parameters to MapServer (e.g. to be able to use GDAL's
+Virtual Filesystems), you can do so by mounting extra configuration files inside
+the container's `/etc/lighttpd/conf.d` directory. Make sure these files have the
+`.conf` extension.
+
+Example configuration snippet:
+
+```
+setenv.add-environment += (
+  "AWS_SECRET_ACCESS_KEY" => env.AWS_SECRET_ACCESS_KEY,
+  "AWS_ACCESS_KEY_ID"     => env.AWS_ACCESS_KEY_ID,
+  "AWS_S3_ENDPOINT"       => env.AWS_S3_ENDPOINT,
+)
+```
+
+Assuming the snippet is saved as `${PWD}/vsis3.conf`, you can run this container
+as follows:
+
+```shell
+docker run --rm -d \
+	-v "${PWD}/vsis3.conf":/etc/lighttpd/conf.d/vsis3.conf:ro \
+	-v some.mapfile:/s3-mapfile:ro \
+	-e AWS_S3_ENDPOINT=s3-host.example:9000 \
+	-e AWS_SECRET_ACCESS_KEY=secret_access_key \
+	-e AWS_ACCESS_KEY_ID=access_key_id \
+	-e MS_MAPFILE=/s3-mapfile \
+	pdok/mapserver
+```
+
+When using multiple includes, make sure to use the `+=` syntax, so you don't
+overwrite includes that came before.
+
 ## Docker image
 
 The Docker image contains 2 stages:

--- a/README.md
+++ b/README.md
@@ -44,40 +44,6 @@ The included EPSG file containing the projection parameters only contains a
 small set of available EPSG code, namely the once used by our organization. If
 one wants to use additional EPSG projections one can overwrite this file.
 
-### Passing extra environment variables to MapServer
-
-If you need to pass extra parameters to MapServer (e.g. to be able to use GDAL's
-Virtual Filesystems), you can do so by mounting extra configuration files inside
-the container's `/etc/lighttpd/conf.d` directory. Make sure these files have the
-`.conf` extension.
-
-Example configuration snippet:
-
-```
-setenv.add-environment += (
-  "AWS_SECRET_ACCESS_KEY" => env.AWS_SECRET_ACCESS_KEY,
-  "AWS_ACCESS_KEY_ID"     => env.AWS_ACCESS_KEY_ID,
-  "AWS_S3_ENDPOINT"       => env.AWS_S3_ENDPOINT,
-)
-```
-
-Assuming the snippet is saved as `${PWD}/vsis3.conf`, you can run this container
-as follows:
-
-```shell
-docker run --rm -d \
-	-v "${PWD}/vsis3.conf":/etc/lighttpd/conf.d/vsis3.conf:ro \
-	-v some.mapfile:/s3-mapfile:ro \
-	-e AWS_S3_ENDPOINT=s3-host.example:9000 \
-	-e AWS_SECRET_ACCESS_KEY=secret_access_key \
-	-e AWS_ACCESS_KEY_ID=access_key_id \
-	-e MS_MAPFILE=/s3-mapfile \
-	pdok/mapserver
-```
-
-When using multiple includes, make sure to use the `+=` syntax, so you don't
-overwrite includes that came before.
-
 ## Docker image
 
 The Docker image contains 2 stages:
@@ -151,6 +117,40 @@ docker run -e DEBUG=0 -e MIN_PROCS=1 -e MAX_PROCS=3 -e MAX_LOAD_PER_PROC=4 \
            -e IDLE_TIMEOUT=20 -e MS_MAPFILE=/srv/data/example.map --rm -d \
            -p 80:80 --name mapserver-run-example -v `pwd`/example:/srv/data pdok/mapserver
 ```
+
+### Passing extra environment variables to MapServer
+
+If you need to pass extra parameters to MapServer (e.g. to be able to use GDAL's
+Virtual Filesystems), you can do so by mounting extra configuration files inside
+the container's `/etc/lighttpd/conf.d` directory. Make sure these files have the
+`.conf` extension.
+
+Example configuration snippet:
+
+```
+setenv.add-environment += (
+  "AWS_SECRET_ACCESS_KEY" => env.AWS_SECRET_ACCESS_KEY,
+  "AWS_ACCESS_KEY_ID"     => env.AWS_ACCESS_KEY_ID,
+  "AWS_S3_ENDPOINT"       => env.AWS_S3_ENDPOINT,
+)
+```
+
+Assuming the snippet is saved as `${PWD}/vsis3.conf`, you can run this container
+as follows:
+
+```shell
+docker run --rm -d \
+	-v "${PWD}/vsis3.conf":/etc/lighttpd/conf.d/vsis3.conf:ro \
+	-v some.mapfile:/s3-mapfile:ro \
+	-e AWS_S3_ENDPOINT=s3-host.example:9000 \
+	-e AWS_SECRET_ACCESS_KEY=secret_access_key \
+	-e AWS_ACCESS_KEY_ID=access_key_id \
+	-e MS_MAPFILE=/s3-mapfile \
+	pdok/mapserver
+```
+
+When using multiple includes, make sure to use the `+=` syntax, so you don't
+overwrite includes that came before.
 
 ## Projections
 

--- a/etc/lighttpd.conf
+++ b/etc/lighttpd.conf
@@ -12,14 +12,16 @@ accesslog.filename = "/dev/stderr"
 
 fastcgi.debug = env.DEBUG
 
-setenv.add-environment = ("MS_MAPFILE" => env.MS_MAPFILE)
+include "/etc/lighttpd/conf.d/*.conf"
+
+setenv.add-environment += ("MS_MAPFILE" => env.MS_MAPFILE)
 
 # ignore MAP= in querystring
 $HTTP["querystring"] =~ "(?i)MAP=" {
   magnet.attract-raw-url-to = ("filter-map.lua")
 }
 
-fastcgi.server = (
+fastcgi.server := (
   "/" => (
     "mapserver" => (
       "socket" => "/tmp/mapserver-fastcgi.socket",


### PR DESCRIPTION
# Omschrijving

We need lighttpd to pass extra environment variables to the mapserv
FastCGI process so it can read data directly out of S3 using GDAL's
vsis3 virtual filesystem.

An include is probably the most flexible solution: if we (or anyone
else) needs more environment variables to be passed to mapserv, they can
simply be added in a config file.

https://dev.kadaster.nl/jira/browse/PDOK-13906

## Type verandering

- Aanpassing van de configuratie

# Checklist:

- [x] Ik heb de code in deze PR zelf nogmaals nagekeken
- [ ] Ik heb mijn code beter achtergelaten dan dat ik het aantrof
- [ ] De code is leesbaar en de moeilijke onderdelen zijn voorzien van commentaar
- [ ] Ik heb de tests toegevoegd/uitgebreid indien nodig
- [ ] Ik heb de tests gedraaid die de werking van mijn wijziging bewijst
- [ ] De [PDOK documentatie](https://github.com/PDOK/interne-documentatie) is bijgewerkt indien nodig.
- [x] Er zit geen gevoelig informatie in deze PR (wachtwoorden etc)